### PR TITLE
Add types to variables in getLastEventThresholdMS to work around cast error

### DIFF
--- a/smartapps/krlaframboise/simple-device-viewer.src/simple-device-viewer.groovy
+++ b/smartapps/krlaframboise/simple-device-viewer.src/simple-device-viewer.groovy
@@ -1373,8 +1373,8 @@ private checkLastEvents() {
 }
 
 private long getLastEventThresholdMS() {
-	def threshold = lastEventThreshold ? lastEventThreshold : 7
-	def unitMS
+	long threshold = lastEventThreshold ? lastEventThreshold : 7
+	long unitMS
 	switch (lastEventThresholdUnit) {
 		case "seconds":
 			unitMS = msSecond()


### PR DESCRIPTION
I've been seeing some issues around type casting on this line on the platform side. Not exactly sure yet why this is causing issues since its typed as a number in the input but this change will help reduce stress on the platform. 
