### PR TITLE
Zxt310 stateful

### DIFF
--- a/devicetypes/krlaframboise/remotec-zxt-310-device.src/remotec-zxt-310-device.groovy
+++ b/devicetypes/krlaframboise/remotec-zxt-310-device.src/remotec-zxt-310-device.groovy
@@ -1,5 +1,5 @@
 /**
- *  Remotec ZXT-310 Device v1.0
+ *  Remotec ZXT-310 Device v1.0.1
  *
  *     (Virtual device used by the Remotec ZXT-310 Device Manager SmartApp)
  *  
@@ -12,6 +12,8 @@
  *
  *  1.0.0 (04/02/2017)
  *    - Initial Release
+ *  1.0.1 (11/06/2018)
+ *    - Added support for ignoring duplicate commands (on / off)
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License. You may obtain a copy of the License at:
@@ -77,7 +79,7 @@ metadata {
 				title: "Button ${btn} Ignore Duplicates:",
 				displayDuringSetup: true,
 				required: false,
-				defaultValue: getBtnIgnoreDuplicatesSetting(btn),
+				defaultValue: getBtnIgnoreDuplicatesSetting(btn)
 		}		
 		input "debugOutput", "bool", 
 			title: "Enable debug logging?", 

--- a/devicetypes/krlaframboise/remotec-zxt-310-device.src/remotec-zxt-310-device.groovy
+++ b/devicetypes/krlaframboise/remotec-zxt-310-device.src/remotec-zxt-310-device.groovy
@@ -244,15 +244,15 @@ private sendEventIfNull(name, value) {
 
 def on() { 
 	logTrace "Executing on()"
-	sendEvent(createEventMap("switch", "on", false))
 	pushTriggeredBtns("on")
+	sendEvent(createEventMap("switch", "on", false))
     return []
 }
 
 def off() {
 	logTrace "Executing off()"
-	sendEvent(createEventMap("switch", "off", false))
 	pushTriggeredBtns("off")
+	sendEvent(createEventMap("switch", "off", false))
     return []
 }
 

--- a/devicetypes/krlaframboise/remotec-zxt-310-device.src/remotec-zxt-310-device.groovy
+++ b/devicetypes/krlaframboise/remotec-zxt-310-device.src/remotec-zxt-310-device.groovy
@@ -73,6 +73,11 @@ metadata {
 				required: false,
 				defaultValue: getBtnRepeatSetting(btn),
 				options: btnRepeatOptions.collect { it.name }				
+			input "btn${btn}IgnoreDuplicates", "bool",
+				title: "Button ${btn} Ignore Duplicates:",
+				displayDuringSetup: true,
+				required: false,
+				defaultValue: getBtnIgnoreDuplicatesSetting(btn),
 		}		
 		input "debugOutput", "bool", 
 			title: "Enable debug logging?", 
@@ -257,7 +262,9 @@ def push() {
 private pushTriggeredBtns(eventName) {
 	btns.each { btn ->
 		if (eventName in getBtnTriggerSettingEvents(btn)) {
-			pushButton(btn)
+				if ((!getBtnIgnoreDuplicatesSetting(btn)) || (device.currentValue("switch") != eventName)) {
+				pushButton(btn)
+			}
 		}
 	}
 }
@@ -336,6 +343,10 @@ private getBtnDelaySetting(btn) {
 }
 private getBtnRepeatSetting(btn) {
 	return getOptionSetting("btn${btn}Repeat", btnRepeatOptions)
+}
+private getBtnIgnoreDuplicatesSetting(btn) {
+	def settingName = "btn${btn}IgnoreDuplicates"
+	return (settings && settings[settingName]) ? settings[settingName] : false
 }
 private getBtnTriggerSettingEvents(btn) {
 	def name = getOptionSetting("btn${btn}Trigger", btnTriggerOptions)


### PR DESCRIPTION
Added on option to ignore duplicate commands for button pushes. This option ignores repeated "On" and "Off" commands when the switch is already in that state. This helps toggle buttons (such as power on and off sharing the same button) stay in sync with the switch. This option is **NOT** enabled by default, which means existing installations will continue to work as they previously did after the update.

![ignoredupesss](https://user-images.githubusercontent.com/2062886/48109758-56e3f680-e20e-11e8-84f5-d103327d1f6b.png)
