### PR TITLE
Leakage Alarm Interval set to 0 to avoid periodic moisture reports

### DIFF
--- a/devicetypes/krlaframboise/strips-multi-sensor.src/strips-multi-sensor.groovy
+++ b/devicetypes/krlaframboise/strips-multi-sensor.src/strips-multi-sensor.groovy
@@ -402,7 +402,7 @@ private getLeakageLevelParam() {
 }
 
 private getLeakageAlarmIntervalParam() {
-	return getParam(14, "Leakage Alarm Interval", 1, 1, moistureIntervalOptions)
+	return getParam(14, "Leakage Alarm Interval", 1, 0, moistureIntervalOptions)
 }
 
 


### PR DESCRIPTION
Edits to Strips multisensor (Drips/Comfort) DH to disable moisture reporting (severely drains battery).