### PR TITLE
Update zooz-power-switch.groovy

### DIFF
--- a/devicetypes/krlaframboise/zooz-power-switch.src/zooz-power-switch.groovy
+++ b/devicetypes/krlaframboise/zooz-power-switch.src/zooz-power-switch.groovy
@@ -955,7 +955,7 @@ private isDuplicateCommand(lastExecuted, allowedMil) {
 }
 
 private isFirmwareVersion2() {
-	return safeToDec(device.currentValue("firmwareVersion")) >= 1.3
+	return safeToDec(device.currentValue("firmwareVersion")) >= 1.03
 }
 
 private logDebug(msg) {


### PR DESCRIPTION
This PR updates `isFirmwareVersion2` to compare the current firmware against `1.03` instead of `1.3`. See [this post](https://community.smartthings.com/t/release-zooz-power-switch-zooz-smart-plug/97220/351) for details.